### PR TITLE
Fix exponential growth of garbage cleaning query run time

### DIFF
--- a/classes/Email-Log.php
+++ b/classes/Email-Log.php
@@ -296,11 +296,11 @@ class Email_Log {
 		$this->database->query( $query );
 
 		// Flag any attachments that can be safely deleted.
-		$query = "UPDATE {$this->attachments_table} attachments
-					LEFT JOIN {$this->email_attachments_table} email_attachments ON email_attachments.attachment_id = attachments.id
+        $query = "UPDATE {$this->attachments_table} attachments
+                    LEFT JOIN (SELECT * FROM {$this->email_attachments_table} GROUP BY attachment_id) AS email_attachments ON email_attachments.attachment_id = attachments.id
 					SET attachments.gc = 1
 					WHERE email_attachments.attachment_id IS NULL";
-		$this->database->query( $query );
+        $this->database->query( $query );
 
 		// Delete the files themselves.
 		$wp_offload_ses->get_attachments()->delete_attachments();


### PR DESCRIPTION
Grouping by attachment ID before joining produces the same behavior as intended and reduced the query run time from 55min at 100% CPU to 700ms for our use case with 42k attachments and 130k email_attachment entries.